### PR TITLE
Broken link to A16Z The Can’t Be Evil NFT Licenses

### DIFF
--- a/docs/standards/TIP/TIP-4/5.md
+++ b/docs/standards/TIP/TIP-4/5.md
@@ -10,7 +10,7 @@ Requires: [TIP-6.1](./../TIP-6/1.md)
 
 ## Abstract
 
-The standard adds the support of [Can't Be Evil NFT licenses](https://github.com/a16z/a16z-contracts) [introduced](https://a16zcrypto.com/introducing-nft-licenses/) by [Andreessen.Horowitz](https://a16z.com).
+The standard adds the support of [Can't Be Evil NFT licenses](https://github.com/a16z/a16z-contracts) [introduced](https://a16zcrypto.com/content/article/introducing-nft-licenses/) by [Andreessen.Horowitz](https://a16z.com).
 
 ## Motivation
 


### PR DESCRIPTION
Introduction link was changed on A16Z website