### PR TITLE
VEP-1155 P1 : Remove TIP4_2 from MultiToken + Additional Changes

### DIFF
--- a/docs/standards/VEP/vep-1155.md
+++ b/docs/standards/VEP/vep-1155.md
@@ -40,8 +40,8 @@ The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL N
 ### Contracts
 
 * `Collection` - contract that mints tokens.
-* `NFT` - [TIP-4.1] contract that stores token information and tokenSupply.
-* `MultiTokenWallet` - [TIP-3] like and [TIP-4.2], [TIP-4.3] compliant constract stores the balance and json metadata. Each MultiToken holder has its own instance of MultiToken wallet contract. In addition it must support TIP-4.2.
+* `NFT` - [TIP-4.1] and [TIP-4.2] contract that stores token information and tokenSupply.
+* `MultiTokenWallet` - [TIP-3] like and [TIP-4.3] compliant constract stores the balance. Each MultiToken holder has its own instance of MultiToken wallet contract.
 * `IndexBasis` - [TIP-4.3] contract, that helps to find all collections by the code hash of which.
 * `Index` - [TIP-4.3] contract, that helps to find:
   * All user tokens in current collection using owner address and collection address.
@@ -62,7 +62,7 @@ pragma ton-solidity >= 0.58.0;
 interface IMultiTokenCollection {
 
     /// @notice This event emits when MulitToken is created
-    /// @param id Unique MultiToken id
+    /// @param id Unique Nft id
     /// @param token Address of MultiToken wallet contract
     /// @param owner Address of MultiToken wallet owner
     /// @param balance count of minted tokens
@@ -70,18 +70,18 @@ interface IMultiTokenCollection {
     event MultiTokenCreated(uint256 id, address token, uint128 balance, address owner, address creator);
 
     /// @notice This event emits when MultiTokens are burned
-    /// @param id Unique MultiToken id
+    /// @param id Unique Nft id
     /// @param count Number of burned tokens
     /// @param owner Address of MultiToken wallet owner
     event MultiTokenBurned(uint256 id, uint128 count, address owner);        
 
     /// @notice Returns the MultiToken wallet code
     /// @return code Returns the MultiToken wallet code as TvmCell
-    function multiTokenWalletCode(uint256 tokenId, bool isEmpty) external view responsible returns (TvmCell code);
+    function multiTokenWalletCode(uint256 id, bool isEmpty) external view responsible returns (TvmCell code);
 
     /// @notice Returns the MultiToken wallet code hash
     /// @return codeHash Returns the MultiToken wallet code hash
-    function multiTokenCodeHash(uint256 tokenId, bool isEmpty) external view responsible returns (uint256 codeHash);
+    function multiTokenCodeHash(uint256 id, bool isEmpty) external view responsible returns (uint256 codeHash);
 
     /// @notice Computes MultiToken wallet address by unique MultiToken id and its owner
     /// @dev Return unique address for all Ids and owners. You find nothing by address for not a valid MultiToken wallet
@@ -97,27 +97,27 @@ interface IMultiTokenCollection {
 #### IMultiTokenCollection.multiTokenWalletCode()
 
 ```solidity
-    function multiTokenWalletCode(uint256 tokenId, bool isEmpty) external view responsible returns (TvmCell code);
+    function multiTokenWalletCode(uint256 id, bool isEmpty) external view responsible returns (TvmCell code);
 ```
 
-* `tokenId` (`uint256`) - Unique MultiToken id
+* `id` (`uint256`) - Unique Nft id
 * `isEmpty` (`bool`) - Balance empty flag
 * `code` (`TvmCell`) - MultiToken contract code
 
 MultiToken wallet is a smart contract deployed from collection smart contract using tokenCode, id and owner address.
-MultiToken wallet code must be salted by collection address, the token id, and isEmpty flag that marks if the wallet has a balance of zero.
+MultiToken wallet code must be salted by collection address, the nft id, and isEmpty flag that marks if the wallet has a balance of zero.
 
 #### IMultiTokenCollection.multiTokenCodeHash()
 
 ```solidity
-    function multiTokenCodeHash(uint256 tokenId, bool isEmpty) public view responsible returns (uint256 codeHash);
+    function multiTokenCodeHash(uint256 id, bool isEmpty) public view responsible returns (uint256 codeHash);
 ```
 
-* `tokenId` (`uint256`) - Unique MultiToken id
+* `id` (`uint256`) - Unique Nft id
 * `isEmpty` (`bool`) - Balance empty flag
 * `codeHash` (`uint256`) - MultiToken wallet contract code hash
 
-The codeHash allows search of all empty or non-empty MultiToken wallet contracts of this collection using base dApp functionality.
+The codeHash allows search of all empty or non-empty MultiToken wallet contracts of this collection for the corresponding nft using base dApp functionality.
 
 #### IMultiTokenCollection.tokenAddress()
 
@@ -125,10 +125,10 @@ The codeHash allows search of all empty or non-empty MultiToken wallet contracts
     function multiTokenWalletAddress(uint256 id, address owner) external view responsible returns (address token);
 ```
 
-* `id` (`uint256`) - Unique MultiToken id
+* `id` (`uint256`) - Unique Nft id
 * `owner` (`address`) - Address of MultiToken wallet owner
 
-Computes MultiToken wallet contract address by unique MultiToken id and its owner. You can check number of owned MultiTokens using base dApp functionality.
+Computes MultiToken wallet contract address by unique Nft id and its owner. You can check number of owned MultiTokens using base dApp functionality.
 
 #### Events
 
@@ -136,7 +136,7 @@ Computes MultiToken wallet contract address by unique MultiToken id and its owne
     event MultiTokenCreated(uint256 id, address token, address owner, address creator);
 ```
 
-* `id` (`uint256`) - Unique MultiToken id
+* `id` (`uint256`) - Unique Nft id
 * `token` (`address`) - Address of MultiToken wallet contract
 * `balance` (`uint128`) - Initial balance
 * `owner` (`address`) - Address of MultiToken owner
@@ -148,7 +148,7 @@ You must emit `MultiTokenCreated` event when MultiToken is minted (initial Multi
     event MultiTokenBurned(uint256 id, uint128 count, address owner);
 ```
 
-* `id` (`uint256`) - Unique MultiToken id
+* `id` (`uint256`) - Unique Nft id
 * `count` (`uint128`) - Number of burned tokens
 * `owner` (`address`) - Address of MultiToken owner
 
@@ -182,9 +182,8 @@ interface IMultiTokenNft {
     function multiTokenSupply() external view responsible returns (uint128 count);
 ```
 
-- `count` (`uint128`) - A count of active MultiTokens minted to this contract
+- `count` (`uint128`) - A count of active MultiTokens minted to this nft
 
-Count increased by one when MultiToken is minted and decreased by one when burned.
 
 ### MultiToken Wallet
 
@@ -506,19 +505,17 @@ interface IDestroyable {
 
 The `symbol()` function (found in the [TIP-3] standard) was not included as we do not believe this is a globally useful piece of data to identify a generic virtual item / asset and are also prone to collisions. Short-hand symbols are used in tickers and currency trading, but they aren’t as useful outside of that space.
 
-The `name()` function (for human-readable asset names, on-chain) was removed from the standard to allow the Metadata JSON to be the definitive asset name and reduce duplication of data. This also allows localization for names.
+The `name()` function (for human-readable asset names, on-chain) was removed from the standard
 
-The `decimals()` function was removed from the standard since the user can't own only fraction of associated data in json. In practice, we can only set it to zero. There is not need to return obvious value.
-
-Since someone should pay for storage fee the decision was made to store json metdata in MultiTokenWallet contract owned by each user.
+The `decimals()` function was removed from the standard since the user can't own only fraction of an nft. In practice, we can only set it to zero. There is not need to return obvious value.
 
 ### MultiTokenWallet destroy
 
 It's possible to destroy MultiTokenWallet or/and indexes contracts when balance is zero. However it results in excessive complexity and additional Venom expenses. We can't handle onBounce if contract is destroyed during transfer. Therefore we need some mechnism to singal back that transfer is completed successfully. This will add no only complexity but additional fee. Besides there are many cases where zero balance is temporary (for example put on sale and cancel sale). As a result it makes sense to have an optional destroy and declare that the owner should decide whether destroy is needed or not.
 
-### Reuse interfaces from [TIP-4.2], [TIP-4.3]
+### Reuse interface from [TIP-4.3]
 
-`TIP4_2JSON_Metadata` interface from [TIP-4.2] and `TIP4_3NFT` interface from [TIP-4.3] standard are used as is for MultiTokenWallet. These interfaces can be used as is and cover needed functinality. However some names can be in doubt (for example `nft` in `getInfo`). There is no reason to introduce new interfaces just to have better naming.
+The `TIP4_3NFT` interface from [TIP-4.3] standard is for MultiTokenWallet. This interface can be used as is and cover needed functinality.
 
 ### Indexes
 

--- a/docs/standards/VEP/vep-1155.md
+++ b/docs/standards/VEP/vep-1155.md
@@ -4,7 +4,7 @@ title: "VEP-1155: Multi-Token"
 
 ```preamble
 VEP: 1155
-author: Evgeny Shatalov <evgeny.a.shatalov@gmail.com>, Aleksei Kolchanov <a.kolchanov@numi.net>
+author: Evgeny Shatalov <evgeny.a.shatalov@gmail.com>, Aleksei Kolchanov <a.kolchanov@numi.net>, Aleksandr Khramtsov <aleksandr.hramcov@gmail.com>
 status: Review
 type: Contract
 created: 2023-03-08

--- a/docs/standards/VEP/vep-1155.md
+++ b/docs/standards/VEP/vep-1155.md
@@ -40,12 +40,13 @@ The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL N
 ### Contracts
 
 * `Collection` - contract that mints tokens.
-* `NFT` - [TIP-4.1] contract that stores token information.
+* `NFT` - [TIP-4.1] contract that stores token information and tokenSupply.
 * `MultiTokenWallet` - [TIP-3] like and [TIP-4.2], [TIP-4.3] compliant constract stores the balance and json metadata. Each MultiToken holder has its own instance of MultiToken wallet contract. In addition it must support TIP-4.2.
 * `IndexBasis` - [TIP-4.3] contract, that helps to find all collections by the code hash of which.
 * `Index` - [TIP-4.3] contract, that helps to find:
-    * All user tokens in current collection using owner address and collection address.
-    * All user tokens in all collections using the owner address.  
+  * All user tokens in current collection using owner address and collection address.
+  * All user tokens in all collections using the owner address.
+  * All tokens with a `tokenId` must have a corresponding nft with the same `nftId`. Where `nftId` == `tokenId`.
 
 code of `IndexBasis` and `Index` contracts and code hash of contracts is fixed and **CANNOT BE CHANGED**
 
@@ -74,18 +75,13 @@ interface IMultiTokenCollection {
     /// @param owner Address of MultiToken wallet owner
     event MultiTokenBurned(uint256 id, uint128 count, address owner);        
 
-    /// @notice Count total MultiToken supply
-    /// @param tokenId Unique MultiToken id
-    /// @return count A count of active MultiTokens minted by this contract for specified tokenId
-    function totalMultiTokenSupply(uint256 tokenId) external view responsible returns (uint128 count);
-
     /// @notice Returns the MultiToken wallet code
     /// @return code Returns the MultiToken wallet code as TvmCell
-    function multiTokenWalletCode() external view responsible returns (TvmCell code);
+    function multiTokenWalletCode(uint256 tokenId, bool isEmpty) external view responsible returns (TvmCell code);
 
     /// @notice Returns the MultiToken wallet code hash
     /// @return codeHash Returns the MultiToken wallet code hash
-    function multiTokenCodeHash() external view responsible returns (uint256 codeHash);
+    function multiTokenCodeHash(uint256 tokenId, bool isEmpty) external view responsible returns (uint256 codeHash);
 
     /// @notice Computes MultiToken wallet address by unique MultiToken id and its owner
     /// @dev Return unique address for all Ids and owners. You find nothing by address for not a valid MultiToken wallet
@@ -98,37 +94,30 @@ interface IMultiTokenCollection {
 
 **NOTE** The [TIP-6.1] identifier for this interface is `0x7A4D5F89`.
 
-#### IMultiTokenCollection.totalMultiTokenSupply()
-
-```solidity
-    function totalMultiTokenSupply(uint256 tokenId) external view responsible returns (uint128 count);
-```
-
-* `tokenId` (`uint256`) - Unique MultiToken id
-* `count` (`uint128`) - A count of active MultiTokens minted by this contract for specified tokenId
-  
-Count increased by one when MultiToken is minted and decreased by one when burned.
-
 #### IMultiTokenCollection.multiTokenWalletCode()
 
 ```solidity
-    function multiTokenWalletCode() public view responsible returns (TvmCell code);
+    function multiTokenWalletCode(uint256 tokenId, bool isEmpty) external view responsible returns (TvmCell code);
 ```
 
+* `tokenId` (`uint256`) - Unique MultiToken id
+* `isEmpty` (`bool`) - Balance empty flag
 * `code` (`TvmCell`) - MultiToken contract code
 
 MultiToken wallet is a smart contract deployed from collection smart contract using tokenCode, id and owner address.
-MultiToken wallet code must be salted by collection address.
+MultiToken wallet code must be salted by collection address, the token id, and isEmpty flag that marks if the wallet has a balance of zero.
 
 #### IMultiTokenCollection.multiTokenCodeHash()
 
 ```solidity
-    function multiTokenCodeHash() public view responsible returns (uint256 codeHash);
+    function multiTokenCodeHash(uint256 tokenId, bool isEmpty) public view responsible returns (uint256 codeHash);
 ```
 
+* `tokenId` (`uint256`) - Unique MultiToken id
+* `isEmpty` (`bool`) - Balance empty flag
 * `codeHash` (`uint256`) - MultiToken wallet contract code hash
 
-The codeHash allows search all MultiToken wallet contracts of this collection using base dApp functionality.
+The codeHash allows search of all empty or non-empty MultiToken wallet contracts of this collection using base dApp functionality.
 
 #### IMultiTokenCollection.tokenAddress()
 
@@ -177,19 +166,45 @@ See the Events for your responsibilities when creating MultiTokens.
 When the supply is just one, the MultiToken is essentially a non-fungible token (NFT). And as is standard for [TIP-4.1]. Since VEP-1155 collection supports [TIP4_1Collection] interface, it's compatible and there is no any difference with [TIP-4.1] standard when dealing with NFT.
 In order to be consistent `NFT` contract must support [TIP-4.1], [TIP-4.2] and [TIP-4.3] standards completely.
 
+Every VEP-1155 compliant nft contract must also implement `IMultiTokenNft`. In the case that supply is just one, but no tokens, `multiTokenSupply()` should return `0`.
+
+```solidity
+interface IMultiTokenNft {
+    /// @notice Count total MultiToken supply
+    /// @return count A count of active MultiTokens minted by collection
+    function multiTokenSupply() external view responsible returns (uint128 count);
+}
+```
+
+#### IMultiTokenNft.multiTokenSupply()
+
+```solidity
+    function multiTokenSupply() external view responsible returns (uint128 count);
+```
+
+- `count` (`uint128`) - A count of active MultiTokens minted to this contract
+
+Count increased by one when MultiToken is minted and decreased by one when burned.
+
 ### MultiToken Wallet
 
 The contract represents information about current MultiToken and control logic.
 
 MultiToken wallet must:
+
 * implement `IMultiTokenWallet` interface and [TIP-6.1] interfaces.
-* implement `TIP4_2JSON_Metadata` interface from [TIP-4.2] standard.
 * implement `TIP4_3NFT` interface from [TIP-4.3] standard.
 * deploy three `Index` contracts [TIP-4.3] with stamp = "fungible" and different code salt:
-    * With zero collection address `collection = "0:0000000000000000000000000000000000000000000000000000000000000000"` in **code salt**.
-    * With non-zero collection address `collection = "0:3bd8…"` **in code salt**.
+  * With zero collection address `collection = "0:0000000000000000000000000000000000000000000000000000000000000000"` in **code salt**.
+  * With non-zero collection address `collection = "0:3bd8…"` **in code salt**.
 * implement `IDestroyable` interface, the owner must decide whether to destroy the MultiToken wallet contract or not if the balance is zero.
 * destruct Index before MultiToken wallet is destroyed.
+* have correct **codesalt** with (in order):
+  * the collection address: `address collection`
+  * the token id: `uint128 id`
+  * the balance empty flag `bool isEmpty`
+  * On a zero balance, `isEmpty` must be set to `true`
+  * On a non-zero balance, `isEmpty` must be set to `false`
 
 Every VEP-1155 compliant token contract must implement the IMultiTokenWallet interface and TIP-6.1 interfaces.
 
@@ -224,7 +239,6 @@ Every VEP-1155 compliant token contract must implement the IMultiTokenWallet int
         /// @notice Returns the number of owned MultiTokens
         /// @return value owned MultiTokens count
         function balance() external view responsible returns (uint128 value);
-        
         /// @notice Transfer MultiTokens to the recipient
         /// @dev Can be called only by MultiToken owner
         /// @param count How many MultiTokens to transfer

--- a/docs/standards/VEP/vep-1155.md
+++ b/docs/standards/VEP/vep-1155.md
@@ -92,7 +92,7 @@ interface IMultiTokenCollection {
 }
 ```
 
-**NOTE** The [TIP-6.1] identifier for this interface is `0x7A4D5F89`.
+**NOTE** The [TIP-6.1] identifier for this interface is `0x5C435318`.
 
 #### IMultiTokenCollection.multiTokenWalletCode()
 
@@ -177,6 +177,8 @@ interface IMultiTokenNft {
     function multiTokenSupply() external view responsible returns (uint128 count);
 }
 ```
+
+**NOTE** The [TIP-6.1] identifier for this interface is `0x243CF87E`.
 
 #### IMultiTokenNft.multiTokenSupply()
 

--- a/docs/standards/VEP/vep-1155.md
+++ b/docs/standards/VEP/vep-1155.md
@@ -168,6 +168,8 @@ In order to be consistent `NFT` contract must support [TIP-4.1], [TIP-4.2] and [
 
 Every VEP-1155 compliant nft contract must also implement `IMultiTokenNft`. In the case that supply is just one, but no tokens, `multiTokenSupply()` should return `0`.
 
+In the case that `count` == 1, this does not necessarily signify that the sole token owner is the `manager` or `owner` of the nft through the `TIP4.1` interface, only that he is the sole token owner.
+
 ```solidity
 interface IMultiTokenNft {
     /// @notice Count total MultiToken supply


### PR DESCRIPTION
## Proposal `VEP-1155` Amendment 1:

This proposal includes the following changes:

* Remove `TIP4_2` from `MultiTokenWallet`, and set `Nft` to be the main source of metadata.
* Add salt markers allowing for the ability to search by codeHash and differentiate between empty and non-empty `MultiTokenWallets`.
* Propose that the `MultiTokenId` in a `MultiTokenWallet` will be the `NftId` setting strict Many-One correspondence. 
* Assign the responsibility of tracking `tokenSupply` to the designated `Nft`. 

See Code [PR](https://github.com/Numiverse/VEP-1155/pull/3) for corresponding changes.