### PR TITLE
fixed contract file name in docs-quick start tip4

### DIFF
--- a/docs/build/development-guides/how-to-create-your-own-non-fungible-tip-4-token/quick-start-developing-with-tip-4.md
+++ b/docs/build/development-guides/how-to-create-your-own-non-fungible-tip-4-token/quick-start-developing-with-tip-4.md
@@ -125,7 +125,7 @@ contract Collection is TIP4_1Collection {
 
 The previous code uses only TIP-4.1 part of TIP-4. But it is kinda useless. To work with your NFT with full NFT experience you should implement [TIP-4.2](../../../standards/TIP/TIP-4/2.md) - standard, which helps you with NFT metadata storing. Also, you will need [TIP-4.3](../../../standards/TIP/TIP-4/3.md) - standard, which helps other dApps to find all your NFT with single query (GQL or JRPC). You should study the information about these standards by links. Implementation of 4.2 and 4.3 is pretty simple.
 
-```solidity title="Collection.tsol" showLineNumbers
+```solidity title="Nft.tsol" showLineNumbers
 pragma ever-solidity >= 0.61.2;
 pragma AbiHeader expire;
 pragma AbiHeader pubkey;


### PR DESCRIPTION
The contract file name was wrong for the given contract, the contract is of Nft.tsol but the file was named as Collection.tsol


![image](https://github.com/venom-blockchain/venom-blockchain.github.io/assets/36509067/d8d353fc-071b-441e-83c9-efabe860af17)
 